### PR TITLE
Refactor locale strings

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -45,11 +45,7 @@
             </b-nav-item-dropdown>
             <b-nav-item>
               <b-form-select class="small" v-model="wiki">
-                <option :value="`enwiki`">English (en)</option>
-                <option :value="`frwiki`">français (fr)</option>
-                <option :value="`dewiki`"> Deutsch (de)</option>
-                <option :value="`wikidatawiki`">Wikidata</option>
-                <option :value="`zhwiki`">中文 (zh)</option>
+                <option v-for="language in languages" :key="language.value" :value="language.value">{{ language.text }}</option>
               </b-form-select>
             </b-nav-item>
           </b-navbar-nav>
@@ -82,11 +78,14 @@
 
 <script>
   import socket from '~/plugins/socket.io.js';
+  import languages from '~/locales/languages.js';
+
   export default {
     data() {
       return {
         liveUserCount: 1,
-        stats: 0
+        stats: 0,
+        languages
       }
     },
     methods: {

--- a/locales/de.js
+++ b/locales/de.js
@@ -1,0 +1,15 @@
+module.exports = {
+    LoginMenuItem: "Anmelden",
+    LogoutMenuItem: "Abmelden",
+    ContributionsMenuItem: "Beiträge",
+    Anonymous: "Anonym",
+    Me: "Ich",
+    Someone: "Jemand",
+    EditSummaryLabel: "Zusammenfassung bearbeiten",
+    LooksGoodBtnLabel: "Sieht gut aus",
+    NotSureBtnLabel: "Nicht sicher",
+    ShouldRevertBtnLabel: "Sollte zurücksetzen",
+    NextBtnLabel: "Nächste",
+    Loading: "Beladung",
+    EditedTimeLabel: "Bearbeitet"
+}

--- a/locales/en.js
+++ b/locales/en.js
@@ -1,0 +1,16 @@
+module.exports = {
+    LoginMenuItem: "Login",
+    LogoutMenuItem: "Logout",
+    ContributionsMenuItem: "Contributions",
+    Anonymous: "Anonymous",
+    Me: "Me",
+    Someone: "Someone",
+    EditSummaryLabel: "Edit summary",
+    LooksGoodBtnLabel: "Looks good",
+    NotSureBtnLabel: "Not sure",
+    ShouldRevertBtnLabel: "Should revert",
+    NextBtnLabel: "Next",
+    Loading: "Loading",
+    EditedTimeLabel: "edited",
+    DiffNotAvailable: "The wikipedia article diff is temporarily not available. You can try to reload it. Sometimes a vandalized revision could be deleted. You can check the page history."
+}

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -1,0 +1,15 @@
+module.exports = {
+    LoginMenuItem: "Connexion",
+    LogoutMenuItem: "Déconnexion",
+    ContributionsMenuItem: "Contributions",
+    Anonymous: "Anonyme",
+    Me: "Moi",
+    Someone: "Quelqu'un",
+    EditSummaryLabel: "Modifier le résumé",
+    LooksGoodBtnLabel: "Cela semble bon",
+    NotSureBtnLabel: "Pas sûr",
+    ShouldRevertBtnLabel: "Devrait revenir",
+    NextBtnLabel: "Suivant",
+    Loading: "Chargement",
+    EditedTimeLabel: "édité"
+}

--- a/locales/languages.js
+++ b/locales/languages.js
@@ -1,0 +1,26 @@
+export default [
+    {
+        value: 'enwiki',
+        text: 'English (en)'
+    },
+    {
+        value: 'frwiki',
+        text: 'français (fr)'
+    },
+    {
+        value: 'dewiki',
+        text: 'Deutsch (de)'
+    },
+    {
+        value: 'wikidatawiki',
+        text: 'Wikidatawiki'
+    },
+    {
+        value: 'zhwiki',
+        text: '中文 (zh)'
+    },
+    {
+        value: 'trwiki',
+        text: 'Turkish (tr)'
+    },
+]

--- a/locales/locales.js
+++ b/locales/locales.js
@@ -1,0 +1,14 @@
+const en = require('./en');
+const zh = require('./zh');
+const fr = require('./fr');
+const de = require('./de');
+const tr = require('./tr');
+
+
+module.exports = {
+    en,
+    zh,
+    fr,
+    de,
+    tr
+}

--- a/locales/tr.js
+++ b/locales/tr.js
@@ -1,0 +1,16 @@
+module.exports = {
+    LoginMenuItem: "Giriş",
+    LogoutMenuItem: "Çıkış",
+    ContributionsMenuItem: "Katkılar",
+    Anonymous: "Anonim",
+    Me: "Ben",
+    Someone: "Birisi",
+    EditSummaryLabel: "Özeti Düzenle",
+    LooksGoodBtnLabel: "İyi Görünüyor",
+    NotSureBtnLabel: "Emin Değilim",
+    ShouldRevertBtnLabel: "Eski Haline Dönmeli",
+    NextBtnLabel: "Sonraki",
+    Loading: "Yükleniyor",
+    EditedTimeLabel: "düzenlendi",
+    DiffNotAvailable: "The wikipedia article diff is temporarily not available. You can try to reload it. Sometimes a vandalized revision could be deleted. You can check the page history."
+}

--- a/locales/zh.js
+++ b/locales/zh.js
@@ -1,0 +1,15 @@
+module.exports = {
+    LoginMenuItem: "登录",
+    LogoutMenuItem: "登出",
+    ContributionsMenuItem: "贡献",
+    Anonymous: "游客",
+    Me: "我",
+    Someone: "别人",
+    EditSummaryLabel: "编辑摘要",
+    LooksGoodBtnLabel: "看着不错",
+    NotSureBtnLabel: "不确定",
+    ShouldRevertBtnLabel: "应该撤回",
+    Loading: "读取中",
+    EditedTimeLabel: "编辑于",
+    DiffNotAvailable: "该页面的版本差异暂时无法读取，可以嘗試重新載入。有时被破壞的版本可能被完全删除，您可以查看页面历史。"
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 const pkg = require('./package');
+const locales = require('./locales/locales');
 require(`dotenv`).config();
 
 console.log(`=================================`);
@@ -93,68 +94,7 @@ module.exports = {
         vueI18n: {
           fallbackLocale: 'en',
           messages: {
-            en: {
-              LoginMenuItem: "Login",
-              LogoutMenuItem: "Logout",
-              ContributionsMenuItem: "Contributions",
-              Anonymous: "Anonymous",
-              Me: "Me",
-              Someone: "Someone",
-              EditSummaryLabel: "Edit summary",
-              LooksGoodBtnLabel: "Looks good",
-              NotSureBtnLabel: "Not sure",
-              ShouldRevertBtnLabel: "Should revert",
-              NextBtnLabel: "Next",
-              Loading: "Loading",
-              EditedTimeLabel: "edited",
-              DiffNotAvailable: "The wikipedia article diff is temporarily not available. You can try to reload it. Sometimes a vandalized revision could be deleted. You can check the page history."
-            },
-            zh: {
-              LoginMenuItem: "登录",
-              LogoutMenuItem: "登出",
-              ContributionsMenuItem: "贡献",
-              Anonymous: "游客",
-              Me: "我",
-              Someone: "别人",
-              EditSummaryLabel: "编辑摘要",
-              LooksGoodBtnLabel: "看着不错",
-              NotSureBtnLabel: "不确定",
-              ShouldRevertBtnLabel: "应该撤回",
-              Loading: "读取中",
-              EditedTimeLabel: "编辑于",
-              DiffNotAvailable: "该页面的版本差异暂时无法读取，可以嘗試重新載入。有时被破壞的版本可能被完全删除，您可以查看页面历史。"
-
-            },
-            fr: {
-              LoginMenuItem: "Connexion",
-              LogoutMenuItem: "Déconnexion",
-              ContributionsMenuItem: "Contributions",
-              Anonymous: "Anonyme",
-              Me: "Moi",
-              Someone: "Quelqu'un",
-              EditSummaryLabel: "Modifier le résumé",
-              LooksGoodBtnLabel: "Cela semble bon",
-              NotSureBtnLabel: "Pas sûr",
-              ShouldRevertBtnLabel: "Devrait revenir",
-              NextBtnLabel: "Suivant",
-              Loading: "Chargement",
-              EditedTimeLabel: "édité"
-            },
-            de: {
-              LoginMenuItem: "Anmelden",
-              LogoutMenuItem: "Abmelden",
-              ContributionsMenuItem: "Beiträge",
-              Anonymous: "Anonym",
-              Me: "Ich",
-              Someone: "Jemand",
-              EditSummaryLabel: "Zusammenfassung bearbeiten",
-              LooksGoodBtnLabel: "Sieht gut aus",
-              NotSureBtnLabel: "Nicht sicher",
-              ShouldRevertBtnLabel: "Sollte zurücksetzen",
-              NextBtnLabel: "Nächste",
-              Loading: "Beladung",
-              EditedTimeLabel: "Bearbeitet"
-            }
+            ...locales
           }
         }
       }


### PR DESCRIPTION
Hi. I refactored locale strings and languages in the `default.vue` file.

- Languages are separated. Each language has its file.
- Languages on the top were hard-coded. Now, they're defined in a file. So, `nuxt.config.js` file is more readable now.