### PR TITLE
Enable localization of edit summary when reverting 

### DIFF
--- a/components/RevisionCard.vue
+++ b/components/RevisionCard.vue
@@ -367,7 +367,14 @@
       redirectToRevert: async function() {
         if (this.myJudgement === `ShouldRevert` && !this.isOverriden()) {
           const version = await this.$axios.$get(`/api/version`);
-          let revertUrl = `${this.getUrlBaseByWiki(this.revision.wiki)}/w/index.php?title=${this.revision.title}&action=edit&undoafter=${this.revision.revision.old}&undo=${this.revision.revision.new}&summary=Identified as test/vandalism using [[:m:WikiLoop Battlefield]](version ${version}). See it or provide your opinion at http://battlefield.wikiloop.org/marked?wikiRevIds=${this.wikiRevId}`;
+          let revertEditSummary = this.$t(
+              `RevertEditSummary`,
+              [
+                `[[:m:WikiLoop Battlefield]]`,
+                `${version}`,
+                `http://battlefield.wikiloop.org/marked?wikiRevIds=${this.wikiRevId}`
+              ]);
+          let revertUrl = `${this.getUrlBaseByWiki(this.revision.wiki)}/w/index.php?title=${this.revision.title}&action=edit&undoafter=${this.revision.revision.old}&undo=${this.revision.revision.new}&summary=${revertEditSummary}`;
           let historyUrl = `${this.getUrlBaseByWiki(this.revision.wiki)}/w/index.php?title=${this.revision.title}&action=history`;
           let result = await this.$axios.$get(`/api/mediawiki`, {params: {
             wiki: this.revision.wiki,

--- a/components/StaticRevisionCard.vue
+++ b/components/StaticRevisionCard.vue
@@ -287,7 +287,14 @@ between Client-Side-Rendering and Server-Side-Rendering -->
       redirectToRevert: async function() {
         if (this.myJudgement === `ShouldRevert` && !this.isOverriden()) {
           const version = await this.$axios.$get(`/api/version`);
-          let revertUrl = `${this.getUrlBaseByWiki(this.revision.wiki)}/w/index.php?title=${this.revision.title}&action=edit&undoafter=${this.revision.revision.old}&undo=${this.revision.revision.new}&summary=Identified as test/vandalism using [[:m:WikiLoop Battlefield]](version ${version}). See it or provide your opinion at http://battlefield.wikiloop.org/marked?wikiRevIds=${this.wikiRevId}`;
+          let revertEditSummary = this.$t(
+              `RevertEditSummary`,
+              [
+                `[[:m:WikiLoop Battlefield]]`,
+                `${version}`,
+                `http://battlefield.wikiloop.org/marked?wikiRevIds=${this.wikiRevId}`
+              ]);
+          let revertUrl = `${this.getUrlBaseByWiki(this.revision.wiki)}/w/index.php?title=${this.revision.title}&action=edit&undoafter=${this.revision.revision.old}&undo=${this.revision.revision.new}&summary=${revertEditSummary}`;
           let historyUrl = `${this.getUrlBaseByWiki(this.revision.wiki)}/w/index.php?title=${this.revision.title}&action=history`;
           let result = await this.$axios.$get(`/api/mediawiki`, {params: {
               wiki: this.revision.wiki,

--- a/locales/de.js
+++ b/locales/de.js
@@ -10,6 +10,7 @@ module.exports = {
     NotSureBtnLabel: "Nicht sicher",
     ShouldRevertBtnLabel: "Sollte zurücksetzen",
     // RevertNowBtnLabel: "Revert now", # TODO: translate
+    // RevertEditSummary: "Identified as test/vandalism using {0} version {1}. See it or provide your opinion at {2}", TODO: translate
     NextBtnLabel: "Nächste",
     Loading: "Beladung",
     EditedTimeLabel: "Bearbeitet"

--- a/locales/en.js
+++ b/locales/en.js
@@ -11,6 +11,7 @@ module.exports = {
     NotSureBtnLabel: "Not sure",
     ShouldRevertBtnLabel: "Should revert",
     RevertNowBtnLabel: "Revert now",
+    RevertEditSummary: "Identified as test/vandalism using {0} version {1}. See it or provide your opinion at {2}",
     NextBtnLabel: "Next",
     Loading: "Loading",
     EditedTimeLabel: "edited",

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -12,6 +12,7 @@ module.exports = {
     NotSureBtnLabel: "Pas sûr",
     ShouldRevertBtnLabel: "Devrait revenir",
     // RevertNowBtnLabel: "Revert now", # TODO: translate
+    // RevertEditSummary: "Identified as test/vandalism using {0} version {1}. See it or provide your opinion at {2}", TODO: translate
     NextBtnLabel: "Suivant",
     Loading: "Chargement",
     EditedTimeLabel: "édité"

--- a/locales/id.js
+++ b/locales/id.js
@@ -11,6 +11,7 @@ module.exports = {
     NotSureBtnLabel: "Tidak yakin",
     ShouldRevertBtnLabel: "Patut dibatalkan",
     RevertNowBtnLabel: "Batalkan sekarang",
+    RevertEditSummary: "Batalkan percobaan/vandalisme menggunakan {0} versi {1}. Lihat atau beri pendapat di {2}",
     NextBtnLabel: "Selanjutnya",
     Loading: "Sedang memuat",
     EditedTimeLabel: "disunting",

--- a/locales/tr.js
+++ b/locales/tr.js
@@ -12,6 +12,7 @@ module.exports = {
     NotSureBtnLabel: "Emin Değilim",
     ShouldRevertBtnLabel: "Eski Haline Dönmeli",
     // RevertNowBtnLabel: "Revert now", # TODO: translate
+    // RevertEditSummary: "Identified as test/vandalism using {0} version {1}. See it or provide your opinion at {2}", TODO: translate
     NextBtnLabel: "Sonraki",
     Loading: "Yükleniyor",
     EditedTimeLabel: "düzenlendi",

--- a/locales/zh.js
+++ b/locales/zh.js
@@ -11,6 +11,7 @@ module.exports = {
     NotSureBtnLabel: "不确定",
     ShouldRevertBtnLabel: "应该撤回",
     // RevertNowBtnLabel: "Revert now", # TODO: translate
+    // RevertEditSummary: "Identified as test/vandalism using {0} version {1}. See it or provide your opinion at {2}", TODO: translate
     Loading: "读取中",
     EditedTimeLabel: "编辑于",
     DiffNotAvailable: "该页面的版本差异暂时无法读取，可以嘗試重新載入。有时被破壞的版本可能被完全删除，您可以查看页面历史。"


### PR DESCRIPTION
Demo: http://wikiloopid.herokuapp.com/
English & Indonesian are translated, other languages fall back to English
This revert summary will be visible to other people in the reviewed Wikipedia, and they might not read English or might prefer not seeing edit summaries in English.
Fix #151 