### PR TITLE
Removed unused socket.io cookie. Closing  #239

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -542,7 +542,7 @@ async function start() {
   app.use(logReqPerf);
 
   const server = http.Server(app);
-  const io = require('socket.io')(server);
+  const io = require('socket.io')(server, { cookie: false });
   app.set('socketio', io);
   await mongoose.connect(process.env.MONGODB_URI,
     { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false }


### PR DESCRIPTION
Disabled 'io' cookie by socket.io since it's not being used for anything. And going forward, browsers will block the cookies with SameSite=None and secure=false.