### PR TITLE
Update pt.yml

### DIFF
--- a/i18n/locales/pt.yml
+++ b/i18n/locales/pt.yml
@@ -15,24 +15,24 @@ Button-RevertNow: Desfazer agora
 Button-ShowJudgements: Mostrar julgamentos
 Button-Undo: Desfazer
 Label-1Month: 1 mês (30d)
-Label-1Quarter: 1 quarto (90d)
+Label-1Quarter: 1 trimestre (90d)
 Label-1Year: 1 ano (365d)
 Label-1day: 1 dia
 Label-1week: 1 semana (7d)
 Label-ActiveUsers: Usuários ativos
-Label-AllTime: Tempo todo
+Label-AllTime: De todos os tempos
 Label-Anonymous: Anônimo
 Label-ArtificialIntelligence: Inteligência artificial
 Label-Author: Autor
 Label-CountOfJudgements: Contagem
 Label-Day: Dia
-Label-DiffView: Diff View
-Label-DirectRevertFailed: Houve uma falha ao desfazer diretamente
-Label-DirectReverted: Desfazer diretamente
+Label-DiffView: Visão Diff
+Label-DirectRevertFailed: Houve uma falha ao reverter diretamente
+Label-DirectReverted: Reverter diretamente
 Label-EditSummary: Resumo da edição
 Label-EditedAt: editado
-Label-Feed: Alimentação
-Label-History: História
+Label-Feed: Atualizações
+Label-History: Histórico
 Label-HumanEditors: Editores humanos
 Label-Judgement: Julgamento
 Label-LastActiveTime: ativo pela última vez
@@ -43,7 +43,7 @@ Label-Looks-Good: Parece bom
 Label-LooksGood: Parece bom
 Label-Me: Eu
 Label-Month: Mês
-Label-My-History: Minha história
+Label-My-History: Meu histórico
 Label-NewJudgement: Novo julgamento
 Label-None: Nenhum
 Label-Not-Sure: Não tenho certeza
@@ -52,7 +52,7 @@ Label-OresBadfaith: ORES Má fé
 Label-OresBadfaith.@meta.@isMachineTranslated: true
 Label-OresBadfaith.@meta.@translatedAt: 2020-07-07T01:09:19.144Z
 Label-OresBadfaith.@meta.@translator: GoogleCloudTranslationAPI project-wikiloop
-Label-OresDamaging: ORES Danificando
+Label-OresDamaging: ORES Danoso
 Label-Overriden: Substituído
 Label-Prompt-Login: Conecte-se
 Label-Rank: Classificação
@@ -61,16 +61,16 @@ Label-Result: Resultado
 Label-RevertSucceeded: A reversão foi bem-sucedida!
 Label-ReviewFeed: Revisar Feed
 Label-ReviewedAndSays: 'revisou {0} e diz'
-Label-Should-Revert: Deve reverter
-Label-ShouldRevert: Deveria ser desfeito
+Label-Should-Revert: Deveria ser revertido
+Label-ShouldRevert: Deveria ser revertido
 Label-Snooze: Soneca
 Label-Someone: Alguém
 Label-Time: Tempo
 Label-TopNumberAnonymousUsers: 'Principais {0} usuários anônimos'
-Label-TopUsers: Usuários principais
+Label-TopUsers: Principais Usuários
 Label-TopWikis: Principais Wikis
 Label-TotalNumber: Total
-Label-User: Do utilizador
+Label-User: Do usuário
 Label-Week: Semana
 Label-YourJudgement: Seu julgamento
 MenuItem-Code: Código
@@ -81,13 +81,13 @@ MenuItem-Stats: Estatísticas
 Message-AJudgementLogged: 'Um julgamento para {0} para a revisão {1} foi registrado.'
 Message-CongratsSuccessfullyReverted: 'Parabéns! você reverteu diretamente {0}.'
 Message-DiffNotAvailable: >-
-  O dif do artigo da Wikipédia está temporariamente indisponível. Pode tentar
-  recarregá-lo.   Às vezes uma revisão vandalizada pode ser eliminada. Pode
+  O diff do artigo da Wikipédia está temporariamente indisponível. Você tentar
+  recarregá-lo. Às vezes uma revisão vandalizada pode ser eliminada. Você pode
   conferir o histórico da página.
-Message-FeedHasNoNewRevisionsClickNextBelow: 'O feed {0} não tem novas revisões, clique no próximo abaixo.'
+Message-FeedHasNoNewRevisionsClickNextBelow: 'O feed {0} não tem novas revisões, clique em próximo abaixo.'
 Message-Login: >-
-  Você sabia que poderia fazer login e preservar seus rótulos em seu nome?
-  Apoiamos o login com a conta da Wikipedia através de Oauth.
+  Você sabia que pode fazer login e preservar seus rótulos em seu nome?
+  O login com a conta da Wikipedia pode ser feito através de Oauth.
 Message-NameVoteAnnouncement: >-
   Caro colaborador, estamos mantendo uma votação para um novo nome, substituindo
   o "Campo de Batalha WikiLoop", que termina em 13 de julho de 2020 às 00:00
@@ -96,10 +96,10 @@ Message-NameVoteAnnouncement: >-
   Por favor vote.
 Message-NoActiveUsersPleaseStartReview: >-
   Nenhum usuário ativo nos últimos 15 minutos. Comece {0} revisando as revisões
-  {1} e torne-se o primeiro.
+  {1} e seja o primeiro.
 Message-Prompt-Login: >-
-  Você sabia que poderia fazer login e preservar suas contribuições em seu nome?
-  Apoiamos o login com a conta da Wikipedia através do Oauth.
+  Você sabia que pode fazer login e preservar seus rótulos em seu nome?
+  O login com a conta da Wikipedia pode ser feito através de Oauth.
 Message-RevertEditSummary: >-
   Identificado como um teste/vandalismo utilizando {0} versão {1}. Ver ou deixar
   sua opinião em {2}


### PR DESCRIPTION
Added better, more idiomatic translations for Portuguese.  

A few notes:
- I added "você" as 2nd-person pronoun where it was missing, because it looked more consistent. This is the common practice for Brazilian speakers; it is a bit informal for European speakers, but I suppose we are not trying to be overly formal here.
- I can't find a good translation for "overriden" in Portuguese. Maybe if knew the context it would be easier.