### PR TITLE
fix: added v-bind where raw variable names where getting leaked

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@
                 ></RevisionCard>
         </template>
 
-      <b-modal id="modal-promote-login" title="$t('Label-Prompt-Login')">
+      <b-modal id="modal-promote-login" v-bind:title="$t('Label-Prompt-Login')">
         {{$t('Message-Prompt-Login')}} <br/>
         <template v-slot:modal-footer="{ ok, hide }">
           <a class="btn-sm btn btn-primary" href="/auth/mediawiki/login">{{$t('Label-Login')}}</a>


### PR DESCRIPTION
The title of the modal dialog prompting anonymous users to login was displaying the raw variable names instead of the localized string. Fixed that by adding a v-bind to the parameter.