### PR TITLE
Update Chinese translation: 损坏/损害(damaging) -> 破坏

### DIFF
--- a/i18n/locales/zh.yml
+++ b/i18n/locales/zh.yml
@@ -61,7 +61,7 @@ Label-Login.@meta.@description: 用于允许用户登录的登录按钮的标签
 Label-Logout: 登出
 Label-Logout.@meta.@description: 登录按钮的标签，允许用户注销。否则它也将用于消息或提示以邀请用户注销。
 Label-LooksGood: 看着不错
-Label-LooksGood.@meta.@description: 这是三种主要判断类型之一的标签，它表示正在接受审核的Wikipedia编辑对Wikipedia而言是有益的和有建设性的，而不是造成损害的。
+Label-LooksGood.@meta.@description: 这是三种主要判断类型之一的标签，它表示正在接受审核的Wikipedia编辑对Wikipedia而言是有益的和有建设性的，而不是破坏性的。
 Label-Me: 我
 Label-Me.@meta.@description: 用于标识用户自己的标签。请确保此处翻译的标签不分性别。
 Label-Month: 月
@@ -76,16 +76,16 @@ Label-NewJudgement.@meta.@description: 用户对Wikipedia做出的新判断的�
 Label-None: 没有
 Label-None.@meta.@description: 空行表和内容单元格或空列表的标签。当没有内容可显示时，通常在用户界面中使用它。
 Label-NotSure: 不确定
-Label-NotSure.@meta.@description: 三种主要判断类型之一的标签表示不确定正在审查的Wikipedia编辑，可能对Wikipedia有益且具有建设性或损害性。
+Label-NotSure.@meta.@description: 三种主要判断类型之一的标签表示不确定正在审查的Wikipedia编辑，可能对Wikipedia有益且具有建设性或破坏性。
 Label-OresBadfaith: ORES恶意
 Label-OresBadfaith.@meta.@description: >-
-  由WMF人工智能评分系统ORES给出的得分和判断标签。该标签具体指的是ORES诚信模型的反面。请参阅https://www.mediawiki.org/wiki/ORES#Advanced_support
+  由WMF人工智能评分系统ORES给出的得分和判断标签。该标签具体指的是ORES诚信模型的反面。请参阅https://www.mediawiki.org/wiki/ORES/zh#高级支持
 Label-OresBadfaith.@meta.@isMachineTranslated: true
 Label-OresBadfaith.@meta.@translatedAt: '2020-07-07T01:09:19.146Z'
 Label-OresBadfaith.@meta.@translator: GoogleCloudTranslationAPI project-wikiloop
-Label-OresDamaging: ORES损坏
+Label-OresDamaging: ORES破坏
 Label-OresDamaging.@meta.@description: >-
-  由WMF人工智能评分系统ORES给出的得分和判断标签。该标签特定指的是ORES的损坏模型。请参阅https://www.mediawiki.org/wiki/ORES#Advanced_support
+  由WMF人工智能评分系统ORES给出的得分和判断标签。该标签特定指的是ORES的破坏模型。请参阅https://www.mediawiki.org/wiki/ORES/zh#高级支持
 Label-Overridden: 覆写
 Label-Overridden.@meta.@description: >-
   表示在Wikipedia文章上进行给定编辑的标签被同一Wikipedia文章上的另一个较新编辑所覆盖。此标签表示这样的编辑已由我们当前的用户还原，或者已由Wikipedia上的另一个Wikipedia编辑器还原或更新。
@@ -110,7 +110,7 @@ Label-ReviewFeed.@meta.@description: 供查阅的Wikipedia的提要，流或流�
 Label-ReviewedAndSays: '评论了{0}并说'
 Label-ReviewedAndSays.@meta.@description: 开始判决的标签和给出修改的理由。
 Label-ShouldRevert: 应该还原
-Label-ShouldRevert.@meta.@description: 三种主要判断类型之一的标签是说，正在审查的Wikipedia编辑损害了Wikipedia，而不是好的和建设性的。
+Label-ShouldRevert.@meta.@description: 三种主要判断类型之一的标签是说，正在审查的Wikipedia编辑对Wikipedia有破坏性而非建设性。
 Label-Snooze: 关闭
 Label-Snooze.@meta.@description: >-
   暂停提醒或通知的按钮标签，换句话说，它的意思是“稍后提醒我”。实际上，当提醒或通知消息再次出现时，将使用贪睡按钮。因此，这也意味着“不是永久解雇，而是暂时解雇”。


### PR DESCRIPTION
This change makes wikiloop-battlefield and the Chinese translated ORES page (https://www.mediawiki.org/wiki/ORES/zh) consistent, so the user won't be confused by inconsistent 'damaging' words when looking at the ORES page.

Also update the ORES url so it point to the Chinese translated ORES page, and rephrases the 'ShouldRevert' description.